### PR TITLE
Add base target tag

### DIFF
--- a/resources/edit.html
+++ b/resources/edit.html
@@ -9,6 +9,7 @@
   <script src="//cdnjs.cloudflare.com/ajax/libs/marked/0.3.5/marked.min.js" type="text/javascript"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/blueimp-md5/1.0.1/js/md5.min.js" type="text/javascript"></script>
   <script src="/js/publishing.js" type="text/javascript"></script>
+  <base target=_new>
 </head>
 
 <body onload="onLoad()" style="height: 100%">


### PR DESCRIPTION
Sometimes while editing i add a link to the left area (markdown editor)

```
<a href=...
```

This if I click the link by mistake, I loose all the edit I did.

This fix, make all links to open in new window, and the user will not redirect in middle of editing before saving.